### PR TITLE
Refactor the Checkout class

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,8 @@
 source 'https://rubygems.org'
 
 group :development do
+  gem 'pry', '~> 0.13.1'
+  gem 'rubocop-rails', '~> 2.5', '>= 2.5.2'
+  gem 'rb-readline', '~> 0.5.5'
   gem 'rspec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,31 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (6.0.2.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2)
+    ast (2.4.0)
+    coderay (1.1.2)
+    concurrent-ruby (1.1.6)
     diff-lcs (1.3)
+    i18n (1.8.2)
+      concurrent-ruby (~> 1.0)
+    jaro_winkler (1.5.4)
+    method_source (1.0.0)
+    minitest (5.14.0)
+    parallel (1.19.1)
+    parser (2.7.1.1)
+      ast (~> 2.4.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rack (2.2.2)
+    rainbow (3.0.0)
+    rb-readline (0.5.5)
+    rexml (3.2.4)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
@@ -15,12 +39,33 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.0)
+    rubocop (0.82.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.7.0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      rexml
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-rails (2.5.2)
+      activesupport
+      rack (>= 1.1)
+      rubocop (>= 0.72.0)
+    ruby-progressbar (1.10.1)
+    thread_safe (0.3.6)
+    tzinfo (1.2.7)
+      thread_safe (~> 0.1)
+    unicode-display_width (1.7.0)
+    zeitwerk (2.3.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  pry (~> 0.13.1)
+  rb-readline (~> 0.5.5)
   rspec
+  rubocop-rails (~> 2.5, >= 2.5.2)
 
 BUNDLED WITH
-   1.15.3
+   1.16.2

--- a/lib/basket.rb
+++ b/lib/basket.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require_relative './item'
+require_relative './order_item'
+
+class Basket
+  attr_reader :prices, :contents
+
+  def initialize(prices, contents: [])
+    @prices = prices
+    @contents = contents
+  end
+
+  def calculate_total
+    items_with_prices.map(&:price).sum
+  end
+
+  def add(item)
+    contents << OrderItem.new(item.to_sym, 1)
+  end
+
+  private
+
+  def items_in_basket
+    contents.each_with_object([]) do |order_item, items_array|
+      if items_array.any? { |item| item.name == order_item.name }
+        items_array.find { |item| item.name == order_item.name }
+                   .quantity += order_item.quantity
+      else
+        items_array << OrderItem.new(order_item.name, order_item.quantity)
+      end
+    end
+  end
+  
+  def items_with_prices
+    items_in_basket.each_with_object([]) do |item, items_array|
+      items_array << Item.new(item.name, calculated_cost_for(item))
+    end
+  end
+
+  def price_for(item)
+    prices.fetch(item.name)
+  end
+
+  def calculated_cost_for(item)
+    if %i[apple pear].include?(item.name)
+      if eligible_for_discount?(item)
+        buy_one_get_one_free(item)
+      else
+        buy_with_no_discount(item)
+      end
+    elsif %i[pineapple].include?(item.name)
+      single_item_half_price_discount(item)
+    elsif %i[banana].include?(item.name)
+      half_price_discount(item)
+    elsif %i[mango].include?(item.name)
+      if eligible_for_discount?(item)
+        buy_three_get_one_free_discount(item)
+      else
+        buy_with_no_discount(item)
+      end
+    else
+      buy_with_no_discount(item)
+    end
+  end
+
+  def eligible_for_discount?(item)
+    (item.quantity % 2).zero? || (item.quantity % 4).zero?
+  end
+
+  def buy_one_get_one_free(item)
+    price_for(item) * (item.quantity / 2)
+  end
+
+  def half_price_discount(item)
+    (price_for(item) / 2) * item.quantity
+  end
+
+  def single_item_half_price_discount(item)
+    (price_for(item) / 2) + price_for(item) * (item.quantity - 1)
+  end
+
+  def buy_three_get_one_free_discount(item)
+    price_for(item) * (item.quantity - 1)
+  end
+
+  def buy_with_no_discount(item)
+    price_for(item) * item.quantity
+  end
+end

--- a/lib/checkout.rb
+++ b/lib/checkout.rb
@@ -1,45 +1,24 @@
+# frozen_string_literal: true
+
+require_relative './basket'
+require_relative './order_item'
+
 class Checkout
-  attr_reader :prices
-  private :prices
+  attr_reader :prices, :basket
+  private :prices, :basket
 
   def initialize(prices)
     @prices = prices
-  end
-
-  def scan(item)
-    basket << item.to_sym
+    @basket = Basket.new(prices)
   end
 
   def total
-    total = 0
-
-    basket.inject(Hash.new(0)) { |items, item| items[item] += 1; items }.each do |item, count|
-      if item == :apple || item == :pear
-        if (count % 2 == 0)
-          total += prices.fetch(item) * (count / 2)
-        else
-          total += prices.fetch(item) * count
-        end
-      elsif item == :banana || item == :pineapple
-        if item == :pineapple
-          total += (prices.fetch(item) / 2)
-          total += (prices.fetch(item)) * (count - 1)
-        else
-          total += (prices.fetch(item) / 2) * count
-        end
-      elsif item == :mango
-        total += prices.fetch(item) * (count - 1)
-      else
-        total += prices.fetch(item) * count
-      end
-    end
-
-    total
+    basket_total
   end
 
   private
 
-  def basket
-    @basket ||= Array.new
+  def basket_total
+    basket.calculate_total
   end
 end

--- a/lib/item.rb
+++ b/lib/item.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Item = Struct.new(:name, :price)

--- a/lib/order_item.rb
+++ b/lib/order_item.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+OrderItem = Struct.new(:name, :quantity)

--- a/spec/basket_spec.rb
+++ b/spec/basket_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'basket'
+
+RSpec.describe Basket do
+  describe '#calculate_total' do
+    subject(:total) { basket.calculate_total }
+
+    let(:basket) { Basket.new(pricing_rules) }
+    let(:pricing_rules) {
+      {
+        apple: 10,
+        orange: 20,
+        pear: 15,
+        banana: 30,
+        pineapple: 100,
+        mango: 200
+      }
+    }
+
+    context 'when no offers apply' do
+      before do
+        basket.add(:apple)
+        basket.add(:orange)
+      end
+
+      it 'returns the base price for the basket' do
+        expect(total).to eq(30)
+      end
+    end
+
+    context 'when a two for 1 applies on apples' do
+      before do
+        basket.add(:apple)
+        basket.add(:apple)
+      end
+
+      it 'returns the discounted price for the basket' do
+        expect(total).to eq(10)
+      end
+
+      context 'and there are other items' do
+        before do
+          basket.add(:orange)
+        end
+
+        it 'returns the correctly discounted price for the basket' do
+          expect(total).to eq(30)
+        end
+      end
+    end
+
+    context 'when a two for 1 applies on pears' do
+      before do
+        basket.add(:pear)
+        basket.add(:pear)
+      end
+
+      it 'returns the discounted price for the basket' do
+        expect(total).to eq(15)
+      end
+
+      context 'and there are other discounted items' do
+        before do
+          basket.add(:banana)
+        end
+
+        it 'returns the correctly discounted price for the basket' do
+          expect(total).to eq(30)
+        end
+      end
+    end
+
+    context 'when a half price offer applies on bananas' do
+      before do
+        basket.add(:banana)
+      end
+
+      it 'returns the discounted price for the basket' do
+        expect(total).to eq(15)
+      end
+    end
+
+    context 'when a half price offer applies on pineapples restricted to 1 per customer' do
+      before do
+        basket.add(:pineapple)
+        basket.add(:pineapple)
+      end
+
+      it 'returns the discounted price for the basket' do
+        expect(total).to eq(150)
+      end
+    end
+
+    context 'when a buy 3 get 1 free offer applies to mangos' do
+      before do
+        4.times { basket.add(:mango) }
+      end
+
+      it 'returns the discounted price for the basket' do
+        expect(total).to eq(600)
+      end
+    end
+  end
+end

--- a/spec/checkout_spec.rb
+++ b/spec/checkout_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'checkout'
 
@@ -6,99 +8,5 @@ RSpec.describe Checkout do
     subject(:total) { checkout.total }
 
     let(:checkout) { Checkout.new(pricing_rules) }
-    let(:pricing_rules) {
-      {
-        apple: 10,
-        orange: 20,
-        pear: 15,
-        banana: 30,
-        pineapple: 100,
-        mango: 200
-      }
-    }
-
-    context 'when no offers apply' do
-      before do
-        checkout.scan(:apple)
-        checkout.scan(:orange)
-      end
-
-      it 'returns the base price for the basket' do
-        expect(total).to eq(30)
-      end
-    end
-
-    context 'when a two for 1 applies on apples' do
-      before do
-        checkout.scan(:apple)
-        checkout.scan(:apple)
-      end
-
-      it 'returns the discounted price for the basket' do
-        expect(total).to eq(10)
-      end
-
-      context 'and there are other items' do
-        before do
-          checkout.scan(:orange)
-        end
-
-        it 'returns the correctly discounted price for the basket' do
-          expect(total).to eq(30)
-        end
-      end
-    end
-
-    context 'when a two for 1 applies on pears' do
-      before do
-        checkout.scan(:pear)
-        checkout.scan(:pear)
-      end
-
-      it 'returns the discounted price for the basket' do
-        expect(total).to eq(15)
-      end
-
-      context 'and there are other discounted items' do
-        before do
-          checkout.scan(:banana)
-        end
-
-        it 'returns the correctly discounted price for the basket' do
-          expect(total).to eq(30)
-        end
-      end
-    end
-
-    context 'when a half price offer applies on bananas' do
-      before do
-        checkout.scan(:banana)
-      end
-
-      it 'returns the discounted price for the basket' do
-        expect(total).to eq(15)
-      end
-    end
-
-    context 'when a half price offer applies on pineapples restricted to 1 per customer' do
-      before do
-        checkout.scan(:pineapple)
-        checkout.scan(:pineapple)
-      end
-
-      it 'returns the discounted price for the basket' do
-        expect(total).to eq(150)
-      end
-    end
-
-    context 'when a buy 3 get 1 free offer applies to mangos' do
-      before do
-        4.times { checkout.scan(:mango) }
-      end
-
-      it 'returns the discounted price for the basket' do
-        expect(total).to eq(600)
-      end
-    end
-  end
+  end  
 end


### PR DESCRIPTION
This commit includes a refactor on the `Checkout` class. The logic for calculating basket total has been moved to the newly created `Basket` class. By doing so, we allow the checkout class to have the option to calculate the total price from a few sources. For example the `Checkout` class can ask the `Basket` class for a total, then ask a Delivery class for a total on delivery cost and then calculate a "checkout" total which includes all costs. I have created two Structs and not classes, as those objects will hold only data (not manipulate it in any way) so there is no need for a class. 